### PR TITLE
Fix for incorrect 'tester' class

### DIFF
--- a/benchmarks/admin.py
+++ b/benchmarks/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from .models import Manifest, Result, ResultData, TestJob
-
+from .tasks import set_testjob_results
 
 @admin.register(Manifest)
 class ManifestAdmin(admin.ModelAdmin):
@@ -18,7 +18,12 @@ class ResultAdmin(admin.ModelAdmin):
 @admin.register(TestJob)
 class TestJobAdmin(admin.ModelAdmin):
     list_display = ('id', 'url', 'status', 'completed', 'created_at')
+    actions = ['force_fetch_results']
 
+    def force_fetch_results(self, request, queryset):
+        for testjob in queryset.all():
+            set_testjob_results.delay(testjob)
+    force_fetch_results.short_description = "Force fetch results"
 
 @admin.register(ResultData)
 class ResultDataAdmin(admin.ModelAdmin):

--- a/benchmarks/tasks.py
+++ b/benchmarks/tasks.py
@@ -38,17 +38,26 @@ def set_testjob_results(self, testjob):
         testjob.testrunnerclass = tester.get_result_class_name(testjob.id)
         testjob.initialized = True
         testjob.save()
+        tester = getattr(testminer, testjob.testrunnerclass)(
+            testjob.testrunnerurl, username, password
+        )
 
     if testjob.status not in ["Complete", "Incomplete", "Canceled"]:
+        logger.debug("Saving job({0}) status: {1}".format(testjob.id, testjob.status))
         testjob.save()
         return
 
     testjob.definition = tester.get_test_job_details(testjob.id)['definition']
     testjob.completed = True
+    logger.debug("Test job({0}) completed: {1}".format(testjob.id, testjob.completed))
     if testjob.status in ["Incomplete", "Canceled"]:
+        logger.debug("Saving job({0}) status: {1}".format(testjob.id, testjob.status))
         testjob.save()
         return
 
+    logger.debug("Calling testminer")
+    logger.debug("Tester class:{0}".format(tester.__class__.__name__))
+    logger.debug("Testjob:{0}".format(testjob.id))
     test_results = tester.get_test_job_results(testjob.id)
 
     if not test_results and testjob.testrunnerclass != "GenericLavaTestSystem":

--- a/benchmarks/testminer.py
+++ b/benchmarks/testminer.py
@@ -12,6 +12,9 @@ from copy import deepcopy
 
 from subprocess import Popen, PIPE, STDOUT
 
+from celery.utils.log import get_task_logger
+logger = get_task_logger("testminer")
+
 try:
     from subprocess import DEVNULL # py3k
 except ImportError:
@@ -497,6 +500,7 @@ class LavaTestSystem(GenericLavaTestSystem):
 class ArtMicrobenchmarksTestResults(LavaTestSystem):
     def get_test_job_results(self, test_job_id):
 
+        logger.info("Fetch microbenchmark results")
         status = self.call_xmlrpc('scheduler.job_status', test_job_id)
 
         if not ('bundle_sha1' in status and status['bundle_sha1']):
@@ -505,6 +509,7 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
         test_result_list = []
 
         sha1 = status['bundle_sha1']
+        logger.debug("Bundle SHA1: {0}".format(sha1))
         result_bundle = self.call_xmlrpc('dashboard.get', sha1)
         bundle = json.loads(result_bundle['content'])
 
@@ -523,6 +528,7 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
         # The test name and test results are in the attachmented pkl file
         # get test results for the attachment
         test_mode = ast.literal_eval(src['test_params'])['MODE']
+        logger.debug("Test mode: {0}".format(test_mode))
         json_attachments = [a['content'] for a in host['attachments'] if a['pathname'].endswith('json')]
 
         if not json_attachments:
@@ -551,6 +557,7 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
             #                    }]
             #            test_result_dict[benchmark] = test_result
             #return [value for key, value in test_result_dict.iteritems()]
+            logger.debug("JSON attachments missing")
             return []
 
 


### PR DESCRIPTION
This commit fixes #13. In case the test job is complete before task is
created, incorrect class is used to fetch results. In addition this
patch adds feature to force result fetching on the test jobs that have
proper results but art-reports fails to retrieve them. Fetching results
doesn't require re-submitting test jobs.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>