### PR TITLE
Build details: explicitly mention "Missing baseline build"

### DIFF
--- a/frontend/static/templates/build_detail.html
+++ b/frontend/static/templates/build_detail.html
@@ -21,11 +21,12 @@
     <dt>Gerrit Patchset Number</dt>
     <dd>{{ build.gerrit_patchset_number || "not set" }}</dd>
 
-    <dt ng-show="baseline">Baseline</dt>
-    <dd ng-show="baseline">
-      <a ng-href="{{ baseline.permalink }}" target="_blank">
-	{{ baseline.build_id }}#{{ baseline.name }}
+    <dt>Baseline</dt>
+    <dd>
+      <a ng-show="baseline" ng-href="{{ baseline.permalink }}" target="_blank">
+	#{{ baseline.build_id }} {{ baseline.name }}
       </a>
+      <em ng-hide="baseline">No baseline build</em>
     </dd>
   </dl>
 


### PR DESCRIPTION
Also, make the label for an existing baseline build consistent with how the
build details page shows in the header.