### PR TITLE
ResultViewSet.benchmark: performance improvement

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -153,9 +153,7 @@ class ResultViewSet(viewsets.ModelViewSet):
     @detail_route()
     def benchmarks(self, request, pk=None):
         result = self.get_object()
-        benchmarks = (benchmarks_models.ResultData.objects
-                      .filter(result=result)
-                      .select_related("benchmark"))
+        benchmarks = result.data.select_related("benchmark").all()
 
         serializer = serializers.ResultDataSerializer(benchmarks, many=True)
         return response.Response(serializer.data)


### PR DESCRIPTION
This removes a N+1 queries issue, bringing down the response time by a
factor of 6.

Fixes #21