### PR TITLE
Added support for CTS and benchmarks

### DIFF
--- a/benchmarks/admin.py
+++ b/benchmarks/admin.py
@@ -22,6 +22,9 @@ class TestJobAdmin(admin.ModelAdmin):
 
     def force_fetch_results(self, request, queryset):
         for testjob in queryset.all():
+            testjob.initialized = False
+            testjob.completed = False
+            testjob.results_loaded = False
             set_testjob_results.delay(testjob)
     force_fetch_results.short_description = "Force fetch results"
 

--- a/benchmarks/metadata.py
+++ b/benchmarks/metadata.py
@@ -6,12 +6,18 @@ def extract_metadata(definition):
     parser.parse()
     return parser.metadata
 
+def extract_name(definition):
+    parser = MetadataParser(definition)
+    parser.parse()
+    return parser.name
+
 
 class MetadataParser(object):
 
     def __init__(self, definition):
         self.definition = definition
         self.metadata = {}
+        self.name = ""
 
     def parse(self):
         if self.definition:
@@ -33,6 +39,8 @@ class MetadataParser(object):
                 if key == 'metadata':
                     for k in data[key]:
                         self.metadata[k] = data[key][k]
+                elif key == 'job_name':
+                    self.name = data[key]
                 else:
                     self.__extract_metadata_recursively__(data[key])
         elif type(data) is list:

--- a/benchmarks/migrations/0038_testjob_name.py
+++ b/benchmarks/migrations/0038_testjob_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('benchmarks', '0037_updated_at_for_testjob_and_result'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='testjob',
+            name='name',
+            field=models.CharField(default=b'', max_length=512, blank=True),
+        ),
+    ]

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.fields import HStoreField
 
 
-from benchmarks.metadata import extract_metadata
+from benchmarks.metadata import extract_metadata, extract_name
 
 
 class ManifestReduced(models.Model):
@@ -212,6 +212,7 @@ class TestJob(models.Model):
 
     id = models.CharField(primary_key=True, max_length=100, blank=False)
 
+    name = models.CharField(blank=True, default="", max_length=512)
     url = models.URLField(blank=True, null=True)
     status = models.CharField(blank=True, default="", max_length=16)
     definition = models.TextField(blank=True, null=True)
@@ -230,6 +231,7 @@ class TestJob(models.Model):
 
     def save(self, *args, **kwargs):
         self.metadata = extract_metadata(self.definition)
+        self.name = extract_name(self.definition)
         super(TestJob, self).save(*args, **kwargs)
         test_jobs = self.result.test_jobs
         self.result.completed = (test_jobs.count() == test_jobs.filter(completed=True).count())

--- a/benchmarks/testminer.py
+++ b/benchmarks/testminer.py
@@ -512,6 +512,8 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
         if not ('bundle_sha1' in status and status['bundle_sha1']):
             return []
 
+        test_result_list = []
+
         sha1 = status['bundle_sha1']
         logger.debug("Bundle SHA1: {0}".format(sha1))
         result_bundle = self.call_xmlrpc('dashboard.get', sha1)
@@ -521,12 +523,12 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
         if target:
             target = target[0]
         else:
-            return []
+            return test_result_list
         host = [t for t in bundle['test_runs'] if t['test_id'] == 'art-microbenchmarks']
         if host:
             host = host[0]
         else:
-            return []
+            return test_result_list
         src = [s for s in host['software_context']['sources'] if 'test_params' in s].next()
         # This is an art-microbenchmarks test
         # The test name and test results are in the attachmented pkl file
@@ -608,7 +610,7 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
 
         host = [t for t in bundle['test_runs'] if t['test_id'] == 'art-microbenchmarks']
         if host:
-            host = iter(host).next()
+            host = host[0]
         else:
             return (None, None)
         json_attachments = [(a['pathname'], a['content']) for a in host['attachments'] if a['pathname'].endswith('json')]
@@ -626,23 +628,21 @@ class ArtWATestResults(LavaTestSystem):
         if not ('bundle_sha1' in status and status['bundle_sha1']):
             return []
 
-        test_result_list = []
-
         sha1 = status['bundle_sha1']
         result_bundle = self.call_xmlrpc('dashboard.get', sha1)
         bundle = json.loads(result_bundle['content'])
 
         target = [t for t in bundle['test_runs'] if t['test_id'] == 'wa2-target']
         if target:
-            target = iter(target).next()
+            target = target[0]
         else:
-            return test_result_list
+            return []
         host = [t for t in bundle['test_runs'] if t['test_id'] == 'wa2-host-postprocessing']
         if host:
-            host = iter(host).next()
+            host = host[0]
         else:
-            return test_result_list
-        src = (s for s in host['software_context']['sources'] if 'test_params' in s).next()
+            return []
+        src = [s for s in host['software_context']['sources'] if 'test_params' in s].next()
         db_attachments = [a['content'] for a in host['attachments'] if a['pathname'].endswith('db')]
 
         # select iteration, workload, metric, value from results;
@@ -714,23 +714,21 @@ class AndroidMultinodeBenchmarkResults(LavaTestSystem):
         if not ('bundle_sha1' in status and status['bundle_sha1']):
             return []
 
-        test_result_list = []
-
         sha1 = status['bundle_sha1']
         result_bundle = self.call_xmlrpc('dashboard.get', sha1)
         bundle = json.loads(result_bundle['content'])
 
         target = [t for t in bundle['test_runs'] if t['test_id'] == 'multinode-target']
         if target:
-            target = iter(target).next()
+            target = target[0]
         else:
-            return test_result_list
+            return []
         host = [t for t in bundle['test_runs'] if t['test_id'] == self.host_test_id]
         if host:
-            host = iter(host).next()
+            host = host[0]
         else:
-            return test_result_list
-        src = (s for s in host['software_context']['sources'] if 'test_params' in s).next()
+            return []
+        src = [s for s in host['software_context']['sources'] if 'test_params' in s].next()
 
         if 'test_results' not in host.keys():
             return []

--- a/benchmarks/testminer.py
+++ b/benchmarks/testminer.py
@@ -512,8 +512,6 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
         if not ('bundle_sha1' in status and status['bundle_sha1']):
             return []
 
-        test_result_list = []
-
         sha1 = status['bundle_sha1']
         logger.debug("Bundle SHA1: {0}".format(sha1))
         result_bundle = self.call_xmlrpc('dashboard.get', sha1)
@@ -521,15 +519,15 @@ class ArtMicrobenchmarksTestResults(LavaTestSystem):
 
         target = [t for t in bundle['test_runs'] if t['test_id'] == 'multinode-target']
         if target:
-            target = iter(target).next()
+            target = target[0]
         else:
-            return test_result_list
+            return []
         host = [t for t in bundle['test_runs'] if t['test_id'] == 'art-microbenchmarks']
         if host:
-            host = iter(host).next()
+            host = host[0]
         else:
-            return test_result_list
-        src = (s for s in host['software_context']['sources'] if 'test_params' in s).next()
+            return []
+        src = [s for s in host['software_context']['sources'] if 'test_params' in s].next()
         # This is an art-microbenchmarks test
         # The test name and test results are in the attachmented pkl file
         # get test results for the attachment

--- a/frontend/static/templates/_pagination.html
+++ b/frontend/static/templates/_pagination.html
@@ -2,12 +2,12 @@
   <ul class="pager">
     <li ng-show="page.page.previous" class="previous">
       <a href="" ng-click="goBack()">
-  	<span aria-hidden="true">&larr;</span> Next
+        <span aria-hidden="true">&larr;</span> Next
       </a>
     </li>
     <li ng-show="page.page.next" class="next">
       <a href="" ng-click="goNext()">
-  	Previous <span aria-hidden="true">&rarr;</span>
+        Previous <span aria-hidden="true">&rarr;</span>
       </a>
     </li>
   </ul>

--- a/frontend/static/templates/build_detail.html
+++ b/frontend/static/templates/build_detail.html
@@ -24,7 +24,7 @@
     <dt>Baseline</dt>
     <dd>
       <a ng-show="baseline" ng-href="{{ baseline.permalink }}" target="_blank">
-	#{{ baseline.build_id }} {{ baseline.name }}
+        #{{ baseline.build_id }} {{ baseline.name }}
       </a>
       <em ng-hide="baseline">No baseline build</em>
     </dd>
@@ -36,56 +36,56 @@
 
     <table class="table table-striped" ng-show="build.test_jobs.length">
       <thead>
-	<tr>
-	  <th>job id</th>
-	  <th class="text-right">status</th>
-	  <th class="text-right">resubmit</th>
-	</tr>
+        <tr>
+          <th>job id</th>
+          <th class="text-right">status</th>
+          <th class="text-right">resubmit</th>
+        </tr>
       </thead>
       <tbody>
-	<tr ng-repeat="test in build.test_jobs">
-	  <td>
-        <a href="{{ test.url }}" target="_blank">{{ test.id }}</a> {{ test.name }}
-	    <a class='toggle-button' ng-hide='isEmpty(test.metadata)' ng-click='display = !display'>
-	      <span ng-hide='display' class='fa fa-plus-square'></span>
-	      <span ng-show='display' class='fa fa-minus-square'></span>
-	    </a>
+        <tr ng-repeat="test in build.test_jobs">
+          <td>
+            <a href="{{ test.url }}" target="_blank">{{ test.id }}</a> {{ test.name }}
+            <a class='toggle-button' ng-hide='isEmpty(test.metadata)' ng-click='display = !display'>
+              <span ng-hide='display' class='fa fa-plus-square'></span>
+              <span ng-show='display' class='fa fa-minus-square'></span>
+            </a>
 
-	    <div ng-show='display'>
-	      <table class='table'>
-		<tr>
-		  <th colspan='2'><strong>Test Job Metadata</strong></th>
-		</tr>
-		<tr ng-repeat='(key, value) in test.metadata'>
-		  <td><tt>{{key}}</tt></td>
-		  <td><tt>{{value}}</tt></td>
-		</tr>
-	      </table>
-	    </div>
-	  </td>
-	  <td class="text-right">
-	    <ng-include src="'/static/templates/_test_job_status.html'" />
-	  </td>
-	  <td class="text-right" style="width: 100px">
+            <div ng-show='display'>
+              <table class='table'>
+                <tr>
+                  <th colspan='2'><strong>Test Job Metadata</strong></th>
+                </tr>
+                <tr ng-repeat='(key, value) in test.metadata'>
+                  <td><tt>{{key}}</tt></td>
+                  <td><tt>{{value}}</tt></td>
+                </tr>
+              </table>
+            </div>
+          </td>
+          <td class="text-right">
+            <ng-include src="'/static/templates/_test_job_status.html'" />
+          </td>
+          <td class="text-right" style="width: 100px">
 
-	    <span ng-hide="{{ test.status==='Complete' || test.status==='Running' || test.status==='Submitted'}}">
-	       <button type="button" class="btn btn-default" ng-hide="test.refresh"
-		       ng-click="test.refresh = true" ng-disabled="testJobUpdate">
-		 <span class="fa fa-refresh"></span>
-	       </button>
+            <span ng-hide="{{ test.status==='Complete' || test.status==='Running' || test.status==='Submitted'}}">
+               <button type="button" class="btn btn-default" ng-hide="test.refresh"
+                       ng-click="test.refresh = true" ng-disabled="testJobUpdate">
+                 <span class="fa fa-refresh"></span>
+               </button>
 
-	       <div class="btn-group" role="group" ng-show="test.refresh">
-		 <button type="button" class="btn btn-success" ng-click="test.refresh = false">
-		   <i class="fa fa-times"></i>
-		 </button>
-		 <button type="button" class="btn btn-warning" ng-click="resubmit(test)">
-		   <i class="fa fa-check"></i>
-		 </button>
-	       </div>
-	    </span>
+               <div class="btn-group" role="group" ng-show="test.refresh">
+                 <button type="button" class="btn btn-success" ng-click="test.refresh = false">
+                   <i class="fa fa-times"></i>
+                 </button>
+                 <button type="button" class="btn btn-warning" ng-click="resubmit(test)">
+                   <i class="fa fa-check"></i>
+                 </button>
+               </div>
+            </span>
 
-	  </td>
-	</tr>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -100,48 +100,48 @@
 
     <form>
       <div class="form-group">
-	<input type="text" ng-model="queryBenchmarks" class="form-control input-sm" placeholder="filter">
+        <input type="text" ng-model="queryBenchmarks" class="form-control input-sm" placeholder="filter">
       </div>
     </form>
 
     <table class="table table-striped benchmarks">
       <thead>
-	<tr>
-	  <th style="width: 60%">name (sample size)</th>
-	  <th class="text-right">current (stdev)</th>
-	  <th class="text-right">previous (stdev)</th>
-	  <th class="text-right">change</th>
-	</tr>
+        <tr>
+          <th style="width: 60%">name (sample size)</th>
+          <th class="text-right">current (stdev)</th>
+          <th class="text-right">previous (stdev)</th>
+          <th class="text-right">change</th>
+        </tr>
       </thead>
       <tbody>
 
-	<tr ng-repeat="item in benchmarksCompare | filter:filterBenchmarksCompared(queryBenchmarks)">
-	  <td>
-	    {{ item.current.benchmark }} / <b>{{ item.current.name }}</b>
-	    ({{ item.current.values.length }})
-	  </td>
-	  <td class="text-right">
-	    {{ item.current.measurement.toFixed(2) }}<br/>
-	    ({{ item.current.stdev.toFixed(2) }})
-	  </td>
-	  <td class="text-right">
-	    {{ item.previous.measurement ? item.previous.measurement.toFixed(2) : "N/A" }}<br/>
-	    {{ item.previous.stdev ? "(" + item.previous.stdev.toFixed(2) + ")": "" }}
-	  </td>
-	  <td class="text-right">
-	    <b>
-	    <span ng-if="item.change > 0" style="color:#77DD77">
-	      {{ item.change.toFixed(2) }} %
-	    </span>
-	    <span ng-if="item.change < 0" style="color:#FF6961">
-	      {{ item.change.toFixed(2) }} %
-	    </span>
-	    </b>
-	    <span ng-if="item.change === null">
-	      N/A
-	    </span>
-	  </td>
-	</tr>
+        <tr ng-repeat="item in benchmarksCompare | filter:filterBenchmarksCompared(queryBenchmarks)">
+          <td>
+            {{ item.current.benchmark }} / <b>{{ item.current.name }}</b>
+            ({{ item.current.values.length }})
+          </td>
+          <td class="text-right">
+            {{ item.current.measurement.toFixed(2) }}<br/>
+            ({{ item.current.stdev.toFixed(2) }})
+          </td>
+          <td class="text-right">
+            {{ item.previous.measurement ? item.previous.measurement.toFixed(2) : "N/A" }}<br/>
+            {{ item.previous.stdev ? "(" + item.previous.stdev.toFixed(2) + ")": "" }}
+          </td>
+          <td class="text-right">
+            <b>
+            <span ng-if="item.change > 0" style="color:#77DD77">
+              {{ item.change.toFixed(2) }} %
+            </span>
+            <span ng-if="item.change < 0" style="color:#FF6961">
+              {{ item.change.toFixed(2) }} %
+            </span>
+            </b>
+            <span ng-if="item.change === null">
+              N/A
+            </span>
+          </td>
+        </tr>
 
       </tbody>
     </table>
@@ -154,31 +154,31 @@
 
     <form>
       <div class="form-group">
-	<input type="text" ng-model="queryBenchmarks" class="form-control input-sm" placeholder="filter">
+        <input type="text" ng-model="queryBenchmarks" class="form-control input-sm" placeholder="filter">
       </div>
     </form>
 
     <table class="table table-striped benchmarks">
       <thead>
-	<tr>
-	  <th style="width: 60%">name (sample size)</th>
-	  <th class="text-right">measurement</th>
-	  <th class="text-right">stdev</th>
-	</tr>
+        <tr>
+          <th style="width: 60%">name (sample size)</th>
+          <th class="text-right">measurement</th>
+          <th class="text-right">stdev</th>
+        </tr>
       </thead>
       <tbody>
-	<tr ng-repeat="item in benchmarks | filter:filterBenchmarks(queryBenchmarks)">
-	  <td>
-	    {{ item.benchmark }} / <b>{{ item.name }}</b>
-	    ({{ item.values.length }})
-	  </td>
-	  <td class="text-right">
-	    {{ item.measurement.toFixed(2)}}
-	  </td>
-	  <td class="text-right">
-	    {{ item.stdev.toFixed(2) }}
-	  </td>
-	</tr>
+        <tr ng-repeat="item in benchmarks | filter:filterBenchmarks(queryBenchmarks)">
+          <td>
+            {{ item.benchmark }} / <b>{{ item.name }}</b>
+            ({{ item.values.length }})
+          </td>
+          <td class="text-right">
+            {{ item.measurement.toFixed(2)}}
+          </td>
+          <td class="text-right">
+            {{ item.stdev.toFixed(2) }}
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/frontend/static/templates/build_detail.html
+++ b/frontend/static/templates/build_detail.html
@@ -45,7 +45,7 @@
       <tbody>
 	<tr ng-repeat="test in build.test_jobs">
 	  <td>
-	    <a href="{{ test.url }}" target="_blank">{{ test.id }}</a>
+        <a href="{{ test.url }}" target="_blank">{{ test.id }}</a> {{ test.name }}
 	    <a class='toggle-button' ng-hide='isEmpty(test.metadata)' ng-click='display = !display'>
 	      <span ng-hide='display' class='fa fa-plus-square'></span>
 	      <span ng-show='display' class='fa fa-minus-square'></span>

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -4,8 +4,8 @@
   <form>
     <div class="form-group">
       <input type="text" ng-change="makeSearch()"
-	     ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
-	     ng-model="search" class="form-control" placeholder="search">
+             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
+             ng-model="search" class="form-control" placeholder="search">
     </div>
   </form>
 
@@ -14,30 +14,30 @@
   <table class="table table-striped">
     <thead>
       <tr>
-	<th style="width: 10%;">#</th>
-	<th style="width: 40%;">build name</th>
-	<th style="width: 35%;">LAVA jobs</th>
-	<th style="width: 15%;">created at</th>
+        <th style="width: 10%;">#</th>
+        <th style="width: 40%;">build name</th>
+        <th style="width: 35%;">LAVA jobs</th>
+        <th style="width: 15%;">created at</th>
       </tr>
     </thead>
     <tbody>
       <tr ng-repeat="build in page.results">
 
-	<td><a ng-href="#/build/{{ build.id }}">#{{ build.build_id }}</a></td>
+        <td><a ng-href="#/build/{{ build.id }}">#{{ build.build_id }}</a></td>
 
-	<td>
-	  <a ng-href="#/build/{{ build.id }}">{{ build.name }}</a> <br/>
-	  <a style="color:#999" href="{{ build.url }}">{{ build.url }}</a>
-	</td>
+        <td>
+          <a ng-href="#/build/{{ build.id }}">{{ build.name }}</a> <br/>
+          <a style="color:#999" href="{{ build.url }}">{{ build.url }}</a>
+        </td>
 
-	<td>
-	  <div ng-repeat="test in build.test_jobs">
+        <td>
+          <div ng-repeat="test in build.test_jobs">
             (<a href="{{ test.url }}" target="_blank">#{{ test.id }}</a>
-	    <ng-include src="'/static/templates/_test_job_status.html'"></ng-include>)
+            <ng-include src="'/static/templates/_test_job_status.html'"></ng-include>)
       </div>
-	</td>
+        </td>
 
-	<td>{{ build.created_at }}</td>
+        <td>{{ build.created_at }}</td>
       </tr>
     </tbody>
   </table>

--- a/frontend/static/templates/manifest_list.html
+++ b/frontend/static/templates/manifest_list.html
@@ -5,8 +5,8 @@
   <form>
     <div class="form-group">
       <input type="text" ng-change="makeSearch()"
-	     ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
-	     ng-model="search" class="form-control" placeholder="search">
+             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
+             ng-model="search" class="form-control" placeholder="search">
     </div>
   </form>
 
@@ -18,37 +18,37 @@
   <table class="table table-striped">
     <tbody>
       <tr ng-repeat-start="item in page.results">
-	<td>
-	  <h4>
-	    <span title="manifest hash">{{ item.manifest_hash }}</span>
-	    <small title="reduced hash">{{ item.reduced_hash }}</small>
-	  </h4>
-	</td>
+        <td>
+          <h4>
+            <span title="manifest hash">{{ item.manifest_hash }}</span>
+            <small title="reduced hash">{{ item.reduced_hash }}</small>
+          </h4>
+        </td>
       </tr>
       <tr ng-repeat-end ng-show="item.results.length">
-	<td style="padding: 0">
+        <td style="padding: 0">
 
-	  <table class="table builds" style="margin-bottom: 0">
-	    <thead>
-	      <tr>
-		<th>build</th>
-		<th class="text-right">change</th>
-		<th class="text-right">patchset</th>
-		<th class="text-right">created at</th>
-	      </tr>
-	    </thead>
-	    <tbody>
-	      <tr ng-repeat="result in item.results">
-		<td>
-		  <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
-		</td>
-		<td class="text-right">{{ result.gerrit_change_number }}</td>
-		<td class="text-right">{{ result.gerrit_patchset_number }}</td>
-		<td class="text-right">{{ result.created_at }}</td>
-	      </tr>
-	    </tbody>
-	  </table>
-	</td>
+          <table class="table builds" style="margin-bottom: 0">
+            <thead>
+              <tr>
+                <th>build</th>
+                <th class="text-right">change</th>
+                <th class="text-right">patchset</th>
+                <th class="text-right">created at</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr ng-repeat="result in item.results">
+                <td>
+                  <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
+                </td>
+                <td class="text-right">{{ result.gerrit_change_number }}</td>
+                <td class="text-right">{{ result.gerrit_patchset_number }}</td>
+                <td class="text-right">{{ result.created_at }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/frontend/static/templates/manifest_reduced_list.html
+++ b/frontend/static/templates/manifest_reduced_list.html
@@ -5,8 +5,8 @@
   <form>
     <div class="form-group">
       <input type="text" ng-change="makeSearch()"
-	     ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
-	     ng-model="search" class="form-control" placeholder="search">
+             ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
+             ng-model="search" class="form-control" placeholder="search">
     </div>
   </form>
 
@@ -22,40 +22,40 @@
   <table class="table table-striped">
     <tbody>
       <tr ng-repeat-start="item in page.results">
-	<td>
-	  <h4>
-	    <span title="reduced hash">{{ item.hash }}</span>
-	  </h4>
-	</td>
+        <td>
+          <h4>
+            <span title="reduced hash">{{ item.hash }}</span>
+          </h4>
+        </td>
       </tr>
 
       <tr ng-repeat-end ng-show="item.manifests">
-	<td style="padding: 0">
+        <td style="padding: 0">
 
-	  <table class="table builds" style="margin-bottom: 0">
-	    <thead>
-	      <tr>
-		<th>build</th>
-		<th class="text-right">manifest</th>
-		<th class="text-right">change</th>
-		<th class="text-right">patchset</th>
-		<th class="text-right">created at</th>
-	      </tr>
-	    </thead>
-	      <tbody ng-repeat="manifest in item.manifests">
-		
-		<tr ng-repeat="result in manifest.results">
-	      	  <td>
-	      	    <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
-	      	  </td>
-		  <td class="text-right">{{ manifest.manifest_hash }}</td>
-	      	  <td class="text-right">{{ result.gerrit_change_number }}</td>
-	      	  <td class="text-right">{{ result.gerrit_patchset_number }}</td>
-	      	  <td class="text-right">{{ result.created_at }}</td>
-		</tr>
-	    </tbody>
-	  </table>
-	</td>
+          <table class="table builds" style="margin-bottom: 0">
+            <thead>
+              <tr>
+                <th>build</th>
+                <th class="text-right">manifest</th>
+                <th class="text-right">change</th>
+                <th class="text-right">patchset</th>
+                <th class="text-right">created at</th>
+              </tr>
+            </thead>
+              <tbody ng-repeat="manifest in item.manifests">
+
+                <tr ng-repeat="result in manifest.results">
+                  <td>
+                    <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
+                  </td>
+                  <td class="text-right">{{ manifest.manifest_hash }}</td>
+                  <td class="text-right">{{ result.gerrit_change_number }}</td>
+                  <td class="text-right">{{ result.gerrit_patchset_number }}</td>
+                  <td class="text-right">{{ result.created_at }}</td>
+                </tr>
+            </tbody>
+          </table>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/frontend/static/templates/stats.html
+++ b/frontend/static/templates/stats.html
@@ -3,22 +3,22 @@
     <form>
       <div class="row">
 
-	<div class="col-md-6">
-	  <div class="form-group">
-	    <label>Branch</label>
-	    <select ng-disabled="disabled" ng-model="branch" class="form-control"
-		    ng-change="change()"
-		    ng-options="item.branch_name for item in branchList"></select>
-	  </div>
-	</div>
+        <div class="col-md-6">
+          <div class="form-group">
+            <label>Branch</label>
+            <select ng-disabled="disabled" ng-model="branch" class="form-control"
+                    ng-change="change()"
+                    ng-options="item.branch_name for item in branchList"></select>
+          </div>
+        </div>
 
-	<div class="col-md-6">
-	  <div class="form-group">
-	    <label>Benchmark</label>
-	    <select ng-disabled="disabled" ng-model="benchmark" class="form-control"
-		    ng-change="change()" ng-options="item.name for item in benchmarkList"></select>
-	  </div>
-	</div>
+        <div class="col-md-6">
+          <div class="form-group">
+            <label>Benchmark</label>
+            <select ng-disabled="disabled" ng-model="benchmark" class="form-control"
+                    ng-change="change()" ng-options="item.name for item in benchmarkList"></select>
+          </div>
+        </div>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Added support for parsing general android benchmark results from
multinode jobs. Same approach is taken for CTS jobs which produce
benchmark-like results (package_name-executed: XX). As additional
feature, test job name is displayed in the build details page.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>