### PR TITLE
benchmarks: allow empty fields on models

### DIFF
--- a/benchmarks/migrations/0039_auto_20160427_0851.py
+++ b/benchmarks/migrations/0039_auto_20160427_0851.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.postgres.fields.hstore
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('benchmarks', '0038_testjob_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='testjob',
+            name='data',
+            field=models.FileField(null=True, upload_to=b'', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='testjob',
+            name='metadata',
+            field=django.contrib.postgres.fields.hstore.HStoreField(default=dict, blank=True),
+        ),
+    ]

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -218,7 +218,7 @@ class TestJob(models.Model):
     definition = models.TextField(blank=True, null=True)
     initialized = models.BooleanField(default=False)
     completed = models.BooleanField(default=False)
-    data = models.FileField(null=True)
+    data = models.FileField(null=True, blank=True)
     testrunnerclass = models.CharField(blank=True, default="GenericLavaTestSystem", max_length=128)
     testrunnerurl = models.CharField(blank=True, default="https://validation.linaro.org/", max_length=256)
 
@@ -227,7 +227,7 @@ class TestJob(models.Model):
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True, null=True)
 
-    metadata = HStoreField(default=dict)
+    metadata = HStoreField(default=dict, blank=True)
 
     def save(self, *args, **kwargs):
         self.metadata = extract_metadata(self.definition)


### PR DESCRIPTION
This allows to change models in admin without entering dummy information
in the mandatory fields

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>