### PR TITLE
testminer: add support for target 'url' type jobs

### DIFF
--- a/benchmarks/testminer.py
+++ b/benchmarks/testminer.py
@@ -121,16 +121,17 @@ class GenericLavaTestSystem(TestSystem):
             if action['command'] == "lava_test_shell":
                 if 'testdef_repos' in action['parameters'].keys():
                     for test_repo in action['parameters']['testdef_repos']:
-                        if test_repo['testdef'].endswith("art-microbenchmarks.yaml"):
-                            return "ArtMicrobenchmarksTestResults"
-                        if test_repo['testdef'].endswith("wa2host_postprocessing.yaml"):
-                            return "ArtWATestResults"
-                        if test_repo['testdef'].endswith("lava-android-benchmark-host.yaml"):
-                            return "AndroidMultinodeBenchmarkResults"
-                        if test_repo['testdef'].endswith("application-benchmark-host.yaml"):
-                            return "AndroidApplicationsBenchmarkResults"
-                        if test_repo['testdef'].endswith("cts-host.yaml"):
-                            return "AndroidCtsTestResults"
+                        if 'testdef' in test_repo.keys():
+                            if test_repo['testdef'].endswith("art-microbenchmarks.yaml"):
+                                return "ArtMicrobenchmarksTestResults"
+                            if test_repo['testdef'].endswith("wa2host_postprocessing.yaml"):
+                                return "ArtWATestResults"
+                            if test_repo['testdef'].endswith("lava-android-benchmark-host.yaml"):
+                                return "AndroidMultinodeBenchmarkResults"
+                            if test_repo['testdef'].endswith("application-benchmark-host.yaml"):
+                                return "AndroidApplicationsBenchmarkResults"
+                            if test_repo['testdef'].endswith("cts-host.yaml"):
+                                return "AndroidCtsTestResults"
         return "GenericLavaTestSystem"
 
     def call_xmlrpc(self, method_name, *method_params):


### PR DESCRIPTION
There is on 'testdef' key when 'url' is used. However this only affects
target side which isn't cruicial when it comes to data post processing.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>