### PR TITLE
benchmarks.set_testjob_result: don't serialize TestJob objects

### DIFF
--- a/benchmarks/admin.py
+++ b/benchmarks/admin.py
@@ -25,7 +25,8 @@ class TestJobAdmin(admin.ModelAdmin):
             testjob.initialized = False
             testjob.completed = False
             testjob.results_loaded = False
-            set_testjob_results.delay(testjob)
+            testjob.save()
+            set_testjob_results.delay(testjob.id)
     force_fetch_results.short_description = "Force fetch results"
 
 @admin.register(ResultData)

--- a/benchmarks/tasks.py
+++ b/benchmarks/tasks.py
@@ -23,7 +23,8 @@ logger = get_task_logger("tasks")
 
 
 @celery_app.task(bind=True)
-def set_testjob_results(self, testjob):
+def set_testjob_results(self, testjob_id):
+    testjob = models.TestJob.objects.get(pk=testjob_id)
     try:
         test_results = get_testjob_data(testjob)
         store_testjob_data(testjob, test_results)
@@ -146,7 +147,7 @@ def check_testjob_completeness(self):
     logger.info("Fetch incomplete TestJobs results, count=%s" % incompleted.count())
 
     for testjob in models.TestJob.objects.filter(completed=False):
-        set_testjob_results.apply_async(args=[testjob])
+        set_testjob_results.apply_async(args=[testjob.id])
 
 
 @celery_app.task(bind=True)

--- a/benchmarks/test_tasks.py
+++ b/benchmarks/test_tasks.py
@@ -69,11 +69,13 @@ def populate_successful_job(job):
 class LavaFetchTest(TestCase):
 
     @patch("benchmarks.tasks.get_testjob_data", lava_xmlrpc_503)
+    @patch("benchmarks.models.TestJob.objects.get", lambda **kw: TestJob())
     def test_ignores_lava_503(self):
         set_testjob_results.apply(args=[None])
         # just not crashing is good enough
 
     @patch("benchmarks.tasks.get_testjob_data", lava_xmlrpc_502)
+    @patch("benchmarks.models.TestJob.objects.get", lambda **kw: TestJob())
     def test_ignores_lava_502(self):
         set_testjob_results.apply(args=[None])
         # just not crashing is good enough
@@ -82,7 +84,7 @@ class LavaFetchTest(TestCase):
     def test_set_testjob_result_saves_testjob(self):
         result = G(Result, manifest__manifest=MINIMAL_XML)
         testjob = G(TestJob, result=result, status='Submitted')
-        set_testjob_results.apply(args=[testjob])
+        set_testjob_results.apply(args=[testjob.id])
 
         testjob_from_db = TestJob.objects.get(pk=testjob.id)
         self.assertEqual("Complete", testjob_from_db.status)
@@ -93,8 +95,8 @@ class LavaFetchTest(TestCase):
         result = G(Result, manifest__manifest=MINIMAL_XML)
         testjob = G(TestJob, result=result, status='Submitted')
 
-        set_testjob_results.apply(args=[testjob])
-        set_testjob_results.apply(args=[testjob])
+        set_testjob_results.apply(args=[testjob.id])
+        set_testjob_results.apply(args=[testjob.id])
 
         self.assertEqual(2, result.data.count())
 


### PR DESCRIPTION
Every time we upgrade and there are changes to the TestJob class, the
objects that were serialized before the upgrade are outdated wrt the
code, and we get errors becasue the code tries to access attributes that
don't exist.

Instead of serializing the entire object, let's serialized just its id,
and pull a fresh object out of the DB exactly when we need it.