### PR TITLE
benchmarks: Changed href in email templates to point to art-reports

### DIFF
--- a/benchmarks/templates/result_progress.html
+++ b/benchmarks/templates/result_progress.html
@@ -8,7 +8,7 @@
 
     <hr>
 
-    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.build_url }}">{{ current.build_id }}#{{ current.name }}</a></h3>
+    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.permalink }}">{{ current.build_id }}#{{ current.name }}</a></h3>
 
     <ul style="padding-left: 0; margin-top: 0;">
         <li>branch: {{ current.branch_name }}</li>
@@ -18,7 +18,10 @@
 
     <hr>
 
-    <h3>Baseline: <a href="{{ baseline.build_url }}">{{ baseline.build_id }}#{{ baseline.name }}</a></h3>
+    <h3>Baseline: <a href="{{ baseline.permalink }}">{{ baseline.build_id }}#{{ baseline.name }}</a></h3>
+    <ul style="padding-left: 0; margin-top: 0;">
+        <li>Jenkins build: <a href="{{ baseline.build_url }}">{{ baseline.build_number }}</a>
+    </ul>
 
     <hr/>
 

--- a/benchmarks/templates/result_progress_baseline_missing.html
+++ b/benchmarks/templates/result_progress_baseline_missing.html
@@ -7,7 +7,7 @@
 
 <hr>
 
-<h3>Change: <a href="{{ current.build_url }}">{{ current.build_id }}#{{ current.name }}</a></h3>
+<h3>Change: <a href="{{ current.permalink }}">{{ current.build_id }}#{{ current.name }}</a></h3>
 
 <h4>
   <li>branch: {{ current.branch_name }}</li>

--- a/benchmarks/templates/result_progress_baseline_no_results.html
+++ b/benchmarks/templates/result_progress_baseline_no_results.html
@@ -7,7 +7,7 @@
 
     <hr>
 
-    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.build_url }}">{{ current.build_id }}#{{ current.name }}</a></h3>
+    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.permalink }}">{{ current.build_id }}#{{ current.name }}</a></h3>
 
     <ul style="padding-left: 0; margin-top: 0;">
         <li>branch: {{ current.branch_name }}</li>
@@ -17,8 +17,10 @@
 
     <hr>
 
-    <h3>Baseline: <a href="{{ baseline.build_url }}">{{ baseline.build_id }}#{{ baseline.name }}</a></h3>
-
+    <h3>Baseline: <a href="{{ baseline.permalink }}">{{ baseline.build_id }}#{{ baseline.name }}</a></h3>
+    <ul style="padding-left: 0; margin-top: 0;">
+        <li>Jenkins build: <a href="{{ baseline.build_url }}">{{ baseline.build_number }}</a>
+    </ul>
     <i>Baseline tests didn't produce useful results. Please try to resubmit tests using ART Reports link.</i>
 
     <p>
@@ -30,8 +32,5 @@
             {% endfor %}
             </ul>
         {% endif %}
-
-        <h5 style="margin-bottom: 0px;">Art Reports:</h5>
-        <a href="{{ baseline.permalink }}">{{ baseline.permalink }}</a>
     </p>
 {% endblock %}

--- a/benchmarks/templates/result_progress_no_results.html
+++ b/benchmarks/templates/result_progress_no_results.html
@@ -7,7 +7,7 @@
 
     <hr>
 
-    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.build_url }}">{{ current.build_id }}#{{ current.name }}</a></h3>
+    <h3 style="margin-bottom: 0px;">Change: <a href="{{ current.permalink }}">{{ current.build_id }}#{{ current.name }}</a></h3>
 
     <ul style="padding-left: 0; margin-top: 0;">
         <li>branch: {{ current.branch_name }}</li>
@@ -28,8 +28,5 @@
             {% endfor %}
             </ul>
         {% endif %}
-
-        <h5 style="margin-bottom: 0px;">Art Reports:</h5>
-        <a href="{{ baseline.permalink }}">{{ current.permalink }}</a>
     </p>
 {% endblock %}


### PR DESCRIPTION
There was no link to art-reports in email templates. All links pointed
to Jenkins/Gerrit. This is fixed now. All links are available.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>