### PR TITLE
install new dependencies for compare.py

### DIFF
--- a/ansible/roles/django/tasks/main.yml
+++ b/ansible/roles/django/tasks/main.yml
@@ -9,6 +9,8 @@
     - python-pip
     - python-virtualenv
     - openjdk-7-jre-headless
+    - python3-scipy
+    - python3-numpy
   tags:
     - install
     - update

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -22,6 +22,8 @@ fi
 if [ ! -d ext/art-testing ]; then
   git clone "https://android-review.linaro.org/linaro/art-testing" ext/art-testing
 fi
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  python3-scipy python3-numpy
 
 if [ ! -f .virtualenv/bin/python ]; then
   virtualenv .virtualenv

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -135,7 +135,7 @@ DATABASES = {
 }
 
 LOGGING['loggers']['qinspect'] = { 'handlers': ['console'], 'level': 'DEBUG',
-				  'propagate': True, }
+                                   'propagate': True, }
 
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True


### PR DESCRIPTION
I decided to do this so we have compare.py working right away (the master
branch will be pulled at any time now). A proper, and more complete solution
can come later together with actual sandboxing.