### PR TITLE
benchmarks.progress: fix programming error

### DIFF
--- a/benchmarks/comparison.py
+++ b/benchmarks/comparison.py
@@ -18,5 +18,5 @@ def render_comparison(testjob_before, testjob_after):
         compare_script,
         testjob_before.data.file.name,
         testjob_after.data.file.name,
-    ])
+    ], stderr=subprocess.STDOUT)
     return output

--- a/benchmarks/progress.py
+++ b/benchmarks/progress.py
@@ -75,7 +75,7 @@ def get_progress_between_results(current, baseline):
     for current_testjob in current.test_jobs.all():
 
         environment = current_testjob.environment
-        baseline_testjob = baseline.testjobs.get(environment=environment)
+        baseline_testjob = baseline.test_jobs.get(environment=environment)
 
         if baseline_testjob:
             progress = Progress(


### PR DESCRIPTION
There was a typo (`testjobs`, should be `test_jobs`), which was not
caught before because the corresponding test case was actually broken.
After fixing the test case, but before fixing the issue, the test case
reproduces the problem.