### PR TITLE
stats: remove usage of "project" field

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -122,17 +122,15 @@ class StatsViewSet(viewsets.ModelViewSet):
             return self.__queryset__
 
         branch = self.request.query_params.get('branch')
-        project = self.request.query_params.get('project')
         environment = self.request.query_params.get('environment')
         benchmarks = self.request.query_params.getlist('benchmark')
 
-        if not (benchmarks and branch and project and environment):
+        if not (benchmarks and branch and environment):
             return self.queryset.none()
 
         testjobs = benchmarks_models.TestJob.objects.filter(environment__identifier=environment)
         testjobs = testjobs.select_related('result')
         testjobs = testjobs.filter(result__branch_name=branch)
-        testjobs = testjobs.filter(result__name=project)
 
         if settings.IGNORE_GERRIT is False:
             testjobs = testjobs.filter(result__gerrit_change_number=None)

--- a/benchmarks/progress.py
+++ b/benchmarks/progress.py
@@ -44,6 +44,7 @@ def get_progress_since(date):
                     environment=environment,
                     result__branch_name=branch,
                     result__name=project,
+                    result__gerrit_change_number=None, # only baseline builds
                 ).order_by('created_at')
 
                 after = testjobs.filter(created_at__gt=date).last()

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -241,8 +241,7 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
 
         var params = {
             branch: $scope.branch && $scope.branch.branch_name,
-            environment: $scope.get_environment_ids(),
-            project: $scope.project && $scope.project.name
+            environment: $scope.get_environment_ids()
         };
         var stats_endpoint;
         if ($scope.benchmark) {
@@ -255,7 +254,7 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
             }
         }
 
-        if (!(params.branch && params.environment.length > 0 && (params.benchmark || params.benchmark_group) && params.project)) {
+        if (!(params.branch && params.environment.length > 0 && (params.benchmark || params.benchmark_group))) {
             return;
         }
 
@@ -398,7 +397,6 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
             env.selected = false;
         });
         $scope.benchmark = undefined;
-        $scope.project = undefined;
         $location.search({});
         document.getElementById('charts').innerHTML = '';
     }
@@ -406,7 +404,6 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
     $q.all([
         $http.get('/api/branch/'),
         $http.get('/api/benchmark/'),
-        $http.get('/api/projects/'),
         $http.get('/api/environments/')
     ]).then(function(response) {
 
@@ -424,13 +421,11 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
         });
         $scope.benchmarkList = benchmarkList;
 
-        $scope.projectList = response[2].data;
-        $scope.environmentList = response[3].data;
+        $scope.environmentList = response[2].data;
 
         var defaults = {
             branch: $routeParams.branch,
             benchmark: $routeParams.benchmark || $routeParams.benchmark_group,
-            project: $routeParams.project,
             environments: $routeParams.environment || []
         };
 
@@ -443,9 +438,6 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
         });
         if (defaults.benchmark) {
             $scope.benchmark = _.find($scope.benchmarkList, ['name', defaults.benchmark]);
-        }
-        if (defaults.project) {
-            $scope.project = _.find($scope.projectList, ['name', defaults.project]);
         }
 
     }).then($scope.change);

--- a/frontend/static/templates/stats.html
+++ b/frontend/static/templates/stats.html
@@ -61,22 +61,6 @@
           </div>
         </div>
 
-        <div class='panel panel-default' ng-show='benchmark'>
-          <div class='panel-heading'>
-            <span ng-show='project'>
-              Project
-            </span>
-            <span ng-hide='project'>
-              <strong>Select project</strong>
-            </span>
-          </div>
-          <div class='panel-body'>
-            <select ng-disabled="disabled" ng-model="project" class="form-control"
-                    ng-change="change()"
-                    ng-options="item.name for item in projectList"></select>
-          </div>
-        </div>
-
         <a class='btn btn-default' ng-show='project' ng-click='reset()'>Reset filter</a>
 
       </form>


### PR DESCRIPTION
The field still exist and can be used for other purposes in the future,
but for now, it does not make much sense to use it as a filter in the
charts page.