### PR TITLE
benchmarks: removed assumption that baseline comes before patch

### DIFF
--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -111,7 +111,6 @@ class Result(models.Model):
             return self.__baseline__
 
         self.__baseline__ = self._default_manager.filter(
-            created_at__lt=self.created_at,
             branch_name=self.branch_name,
             gerrit_change_number=None,
             manifest__reduced__hash=self.manifest.reduced.hash
@@ -132,7 +131,6 @@ class Result(models.Model):
             data_count=Count('data')
         ).filter(
             data_count__gt=0,
-            created_at__lt=self.created_at,
             branch_name=self.branch_name,
             gerrit_change_number=None,
             manifest__reduced__hash=self.manifest.reduced.hash


### PR DESCRIPTION
Baseline builds might be reported after the patched build is already in
the database. In this case email reporting will show "no baseline".
However after the baseline build is introduced to database, the detailed
view should use it to compare test results. So assumption that baseline
comes before patch is wrong.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>