### PR TITLE
stats benchmar box freezes when adding the same metric twice

### DIFF
--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -346,8 +346,10 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
 
     $scope.addBenchmark = function() {
         var benchmark = $scope.benchmark;
-        $scope.benchmarks.push(benchmark);
-        $scope.updateCharts();
+        if (! _.find($scope.benchmarks, benchmark)) {
+            $scope.benchmarks.push(benchmark);
+            $scope.updateCharts();
+        }
         $scope.benchmark = undefined;
     }
 


### PR DESCRIPTION
This is a big that was introduced by PR #84. The probelm shows up after following steps:
1. open stats page (overall summary is displayed)
2. try to add 'overall summary' again - nothing happens
3. try to add some other metric

This results in chart added to the display area but the box with list of the charts is not updated.