### PR TITLE
add UI for comparing arbitrary builds

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -222,7 +222,11 @@ class ResultViewSet(viewsets.ModelViewSet):
     @detail_route()
     def benchmarks_compare(self, request, pk=None):
         result = self.get_object()
-        previous = result.to_compare()
+        comparison_base = request.query_params.get('comparison_base')
+        if comparison_base:
+            previous = benchmarks_models.Result.objects.get(pk=comparison_base)
+        else:
+            previous = result.to_compare()
         if not previous:
             return response.Response([])
 

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -114,7 +114,7 @@ class Result(models.Model):
         if self.__baseline__ != False:
             return self.__baseline__
 
-        self.__baseline__ = self._default_manager.filter(
+        self.__baseline__ = self._default_manager.exclude(id=self.id).filter(
             branch_name=self.branch_name,
             gerrit_change_number=None,
             manifest__reduced__hash=self.manifest.reduced.hash

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -33,8 +33,8 @@
 	</div>
 
 	<ul class="nav navbar-nav">
-	  <li ng-class="{active: viewName == 'ManifestList'}"><a href="#/manifests/">Manifests</a></li>
-          <li ng-class="{active: viewName == 'BuildList'}"><a href="#/builds/">Builds</a></li>
+	  <li ng-class="{active: viewName == 'ManifestList' || viewName =='ManifestReducedList'}"><a href="#/manifests/">Manifests</a></li>
+          <li ng-class="{active: viewName == 'BuildList' || viewName == 'CompareBuilds'}"><a href="#/builds/">Builds</a></li>
 	  <li ng-class="{active: viewName == 'Stats'}"><a href="#/stats/">Stats</a></li>
 	</ul>
 

--- a/frontend/static/main.css
+++ b/frontend/static/main.css
@@ -69,10 +69,6 @@ input, select, button, .btn {
     border-radius: 0 !important;
 }
 
-#build-list form {
-    margin: 30px 0 40px 0;
-}
-
 .checkbox input[type="checkbox"] {
     margin-left: 0px !important;
 }

--- a/frontend/static/main.css
+++ b/frontend/static/main.css
@@ -57,11 +57,11 @@ nav .navbar-brand {
     border-bottom: 1px solid #eee;
 }
 
-#build-detail table.benchmarks {
+table.benchmarks {
     font-size: 13px;
 }
 
-#build-detail table tbody>tr>td {
+table tbody>tr>td {
     vertical-align: middle;
 }
 

--- a/frontend/static/main.css
+++ b/frontend/static/main.css
@@ -98,7 +98,7 @@ input, select, button, .btn {
     border-bottom: 2px #aaa solid;
 }
 
-#manifest-list .nav {
+#manifest-list .nav, #build-nav .nav {
     margin: 10px 0 15px 0;
     background-color: #eee;
 }

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -141,13 +141,33 @@ app.controller(
      }]
 );
 
+app.filter('count_by_status', function() {
+    return function(test_jobs) {
+        var data = {};
+        _.each(test_jobs, function(t) {
+            var st = t.status;
+            if (data[st]) {
+                data[st] += 1;
+            } else {
+                data[st] = 1
+            }
+        });
+
+        var text = _.map(data, function(count, st) {
+            return st + ': ' + count;
+        })
+
+        return _.join(text, ', ');
+    }
+});
+
 
 app.controller(
     'BuildList',
 
-    ['$scope', '$http', '$routeParams', '$location',
+    ['$scope', '$http', '$routeParams', '$location', 'count_by_statusFilter',
 
-     function($scope, $http, $routeParams, $location) {
+     function($scope, $http, $routeParams, $location, count_by_statusFilter) {
 
          var params = {
              'search': $routeParams.search,
@@ -384,7 +404,6 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
                                           min: _.min(point.values),
                                           max: _.max(point.values),
                                           result_id: point.result,
-                                          build_id: point.build_id
                                       };
                                   })
                                   });
@@ -462,7 +481,7 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
                             range,
                             '</p>',
                             '<p>',
-                            '<a href="#/build/' + this.result_id + '">See details for build #' + this.build_id + '</a>',
+                            '<a href="#/build/' + this.result_id + '">See details for build #' + this.result_id + '</a>',
                             '</p>'
                             ]
                             return _.join(html, '');

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -193,6 +193,21 @@ app.controller(
                      $scope.page = response.data;
                  });
          };
+
+
+         $scope.setCompareFrom = function(id) {
+             $scope.compareFrom = id;
+             return true;
+         }
+
+         $scope.setCompareTo = function(id) {
+             if (id == $scope.compareFrom) {
+                 return false;
+             } else {
+                 $scope.compareTo = id;
+                 return true;
+             }
+         }
      }]
 );
 

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -146,33 +146,31 @@ app.controller(
      }]
 );
 
-app.filter('count_by_status', function() {
-    return function(test_jobs) {
-        var data = {};
-        _.each(test_jobs, function(t) {
-            var st = t.status;
-            if (data[st]) {
-                data[st] += 1;
-            } else {
-                data[st] = 1
-            }
-        });
+function count_by_status(test_jobs) {
+    var data = {};
+    _.each(test_jobs, function(t) {
+        var st = t.status;
+        if (data[st]) {
+            data[st] += 1;
+        } else {
+            data[st] = 1
+        }
+    });
 
-        var text = _.map(data, function(count, st) {
-            return st + ': ' + count;
-        })
+    var text = _.map(data, function(count, st) {
+        return st + ': ' + count;
+    })
 
-        return _.join(text, ', ');
-    }
-});
+    return _.join(text, '<br/>');
+}
 
 
 app.controller(
     'BuildList',
 
-    ['$scope', '$http', '$routeParams', '$location', 'count_by_statusFilter',
+    ['$scope', '$http', '$routeParams', '$location', '$sce',
 
-     function($scope, $http, $routeParams, $location, count_by_statusFilter) {
+     function($scope, $http, $routeParams, $location, $sce) {
 
          var params = {
              'search': $routeParams.search,
@@ -181,6 +179,9 @@ app.controller(
 
          $http.get('/api/result/', {params: params}).then(function(response) {
              $scope.page = response.data;
+             _.each($scope.page.results, function(build) {
+                 build.test_jobs_count_by_status = $sce.trustAsHtml(count_by_status(build.test_jobs));
+             })
          });
 
          $scope.search = $routeParams.search;

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -208,6 +208,14 @@ app.controller(
                  return true;
              }
          }
+
+         $scope.compare = function() {
+             if (!($scope.compareFrom && $scope.compareTo)) {
+                 alert('Please select builds to compare first');
+                 return;
+             }
+             location.href = '#/builds/compare/?from=' + $scope.compareFrom + '&to=' + $scope.compareTo;
+         }
      }]
 );
 

--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -315,9 +315,14 @@ app.controller('CompareBuilds', ['$scope', '$http', '$routeParams', '$q', '$rout
     }
 
     $scope.compare = function() {
+        if (!($scope.compareFrom && $scope.compareTo)) {
+            alert('Please inform the build numbers to compare');
+            return;
+        }
         $location.search({'from': $scope.compareFrom, 'to': $scope.compareTo});
         $scope.loading = true;
         $scope.ready = false;
+        $scope.error = null;
         $q.all([
             $http.get('/api/result/' + $scope.compareFrom + '/'),
             $http.get('/api/result/' + $scope.compareTo + '/'),
@@ -327,6 +332,8 @@ app.controller('CompareBuilds', ['$scope', '$http', '$routeParams', '$q', '$rout
             $scope.buildFrom = response[0].data;
             $scope.buildTo = response[1].data;
             $scope.comparisons = response[2].data;
+        }).catch(function(error) {
+            $scope.error = error;
         });
     }
     if ($routeParams.from && $routeParams.to) {

--- a/frontend/static/templates/build_detail.html
+++ b/frontend/static/templates/build_detail.html
@@ -6,13 +6,15 @@
 
 <div id="build-detail" ng-show="build">
 
-  <h1 class="md-display-1"> <small>{{ build.created_at }}</small><br/>#{{ build.build_id }} {{ build.name }}</h1>
+  <h1 class="md-display-1">
+    Build #{{ build.id }}
+    <small>{{ build.created_at}}</small>
+  </h1>
 
-  <hr/>
-  <a ng-href="{{ build.build_url }}" target="_blank">{{ build.build_url }}</a>
   <hr/>
 
   <dl class="dl-horizontal">
+
     <dt>Branch</dt>
     <dd>{{ build.branch_name || "not set"}}</dd>
 
@@ -25,10 +27,19 @@
     <dt>Gerrit Patchset Number</dt>
     <dd>{{ build.gerrit_patchset_number || "not set" }}</dd>
 
+
+    <dt>Original build</dt>
+    <dd>
+    <a ng-href="{{ build.build_url }}" target="_blank">
+      {{build.name}} #{{ build.build_id }}
+      <i class='fa fa-external-link'></i>
+    </a>
+    </dd>
+
     <dt>Baseline</dt>
     <dd>
       <a ng-show="baseline" ng-href="{{ baseline.permalink }}" target="_blank">
-        #{{ baseline.build_id }} {{ baseline.name }}
+        #{{ baseline.id }}
       </a>
       <em ng-hide="baseline">No baseline build</em>
     </dd>

--- a/frontend/static/templates/build_detail.html
+++ b/frontend/static/templates/build_detail.html
@@ -41,6 +41,9 @@
       <a ng-show="baseline" ng-href="{{ baseline.permalink }}" target="_blank">
         #{{ baseline.id }}
       </a>
+      <a ng-show="baseline" ng-href="#/builds/compare/?from={{baseline.id}}&to={{build.id}}" target="_blank">
+        (compare)
+      </a>
       <em ng-hide="baseline">No baseline build</em>
     </dd>
   </dl>

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -9,9 +9,12 @@
     </div>
   </form>
 
+  <form>
   <table class="table table-striped">
     <thead>
       <tr>
+        <th></th>
+        <th ng-show='compareFrom'></th>
         <th>#</th>
         <th>branch</th>
         <th>build name</th>
@@ -22,6 +25,12 @@
     </thead>
     <tbody>
       <tr ng-repeat="build in page.results">
+
+        <td><input type='radio' name='compareFrom' value='{{build.id}}' ng-click='setCompareFrom(build.id)'/></td>
+        <td ng-show='compareFrom'>
+          <input ng-show='compareFrom != build.id' type='radio' name='compareTo' value='{{build.id}}' ng-click='setCompareTo(build.id)'/>
+          <a ng-show='compareFrom != build.id && compareTo == build.id' href='#/builds/compare/?from={{compareFrom}}&to={{build.id}}' title='compare selected builds'>compare</a>
+        </td>
 
         <td><a ng-href="#/build/{{ build.id }}">#{{ build.id }}</a></td>
 
@@ -48,6 +57,7 @@
       </tr>
     </tbody>
   </table>
+  </form>
 
   <pagination page="page"></pagination>
 

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -9,21 +9,23 @@
     </div>
   </form>
 
-  <pagination page="page"></pagination>
-
   <table class="table table-striped">
     <thead>
       <tr>
-        <th style="width: 10%;">#</th>
-        <th style="width: 40%;">build name</th>
-        <th style="width: 35%;">LAVA jobs</th>
-        <th style="width: 15%;">created at</th>
+        <th>#</th>
+        <th>branch</th>
+        <th>build name</th>
+        <th>Test jobs</th>
+        <th>created at</th>
+        <th>Original #</th>
       </tr>
     </thead>
     <tbody>
       <tr ng-repeat="build in page.results">
 
-        <td><a ng-href="#/build/{{ build.id }}">#{{ build.build_id }}</a></td>
+        <td><a ng-href="#/build/{{ build.id }}">#{{ build.id }}</a></td>
+
+        <td><a ng-href="#/build/{{ build.id }}">{{ build.branch_name }}</a></td>
 
         <td>
           <a ng-href="#/build/{{ build.id }}">{{ build.name }}</a> <br/>
@@ -31,13 +33,18 @@
         </td>
 
         <td>
-          <div ng-repeat="test in build.test_jobs">
-            (<a href="{{ test.url }}" target="_blank">#{{ test.id }}</a>
-            <ng-include src="'/static/templates/_test_job_status.html'"></ng-include>)
-      </div>
+          {{build.test_jobs|count_by_status}}
         </td>
 
         <td>{{ build.created_at }}</td>
+
+        <td>
+          <a href="{{build.build_url}}">
+            #{{build.build_id}}
+            <i class='fa fa-external-link'></i>
+          </a>
+        </td>
+
       </tr>
     </tbody>
   </table>

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -1,6 +1,14 @@
+<div id='build-nav'>
+  <ul class="nav nav-pills nav-pills-sm">
+    <li role="presentation" class="active"><a href="#/builds/">build list</a></li>
+    <li role="presentation"><a href="#/builds/compare/">compare builds</a></li>
+  </ul>
+</div>
+
 <i ng-show="!page" class="fa fa-cog fa-spin"></i>
 
 <div ng-show="page" id="build-list">
+
   <form>
     <div class="form-group">
       <input type="text" ng-change="makeSearch()"

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -17,6 +17,8 @@
     </div>
   </form>
 
+  <a class='btn btn-primary' ng-click='compare()' title='compare selected builds'>Compare selected builds</a>
+
   <form>
   <table class="table table-striped">
     <thead>
@@ -37,7 +39,6 @@
         <td><input type='radio' name='compareFrom' value='{{build.id}}' ng-click='setCompareFrom(build.id)'/></td>
         <td ng-show='compareFrom'>
           <input ng-show='compareFrom != build.id' type='radio' name='compareTo' value='{{build.id}}' ng-click='setCompareTo(build.id)'/>
-          <a ng-show='compareFrom != build.id && compareTo == build.id' href='#/builds/compare/?from={{compareFrom}}&to={{build.id}}' title='compare selected builds'>compare</a>
         </td>
 
         <td><a ng-href="#/build/{{ build.id }}">#{{ build.id }}</a></td>
@@ -66,6 +67,8 @@
     </tbody>
   </table>
   </form>
+
+  <a class='btn btn-primary' ng-click='compare()' title='compare selected builds'>Compare selected builds</a>
 
   <pagination page="page"></pagination>
 

--- a/frontend/static/templates/build_list.html
+++ b/frontend/static/templates/build_list.html
@@ -50,8 +50,7 @@
           <a style="color:#999" href="{{ build.url }}">{{ build.url }}</a>
         </td>
 
-        <td>
-          {{build.test_jobs|count_by_status}}
+        <td ng-bind-html='build.test_jobs_count_by_status'>
         </td>
 
         <td>{{ build.created_at }}</td>

--- a/frontend/static/templates/compare.html
+++ b/frontend/static/templates/compare.html
@@ -1,0 +1,117 @@
+<h1>
+  Compare builds
+  <span ng-show='buildFrom && buildTo'>
+    <a href='#/build/{{buildFrom.id}}'>#{{buildFrom.id}}</a>
+    and
+    <a href='#/build/{{buildTo.id}}'>#{{buildTo.id}}</a>
+  </span>
+</h1>
+
+<form class='form-inline'>
+
+  <div class="form-group">
+    <label for="compareFrom">Compare:</label>
+    <input
+      type='text'
+      name='from'
+      class="form-control"
+      id="compareFrom"
+      ng-model='compareFrom'
+      placeholder='build number'
+    />
+  </div>
+
+  <div class="form-group">
+    <label for="compareTo">to:</label>
+    <input
+      type='text'
+      name='from'
+      class="form-control"
+      id="compareTo"
+      ng-model='compareTo'
+      placeholder='build number'
+    />
+  </div>
+
+  <input
+    type='button'
+    class='btn btn-primary'
+    value='Compare'
+    ng-click='compare()'
+  />
+
+</form>
+
+<i ng-show='loading && !ready' class='fa fa-cog fa-spin'></i>
+
+<div ng-show="ready">
+
+  <h2>Benchmarks</h2>
+
+  <form>
+    <div class="form-group">
+      <input type="text" ng-model="queryBenchmarks" class="form-control input-sm" placeholder="filter">
+    </div>
+    <div class='checkbox'>
+      <input id='show-boring' type='checkbox' ng-model='showBoring'/>
+      <label for='show-boring'>Show non-significant results</label>
+    </div>
+
+  </form>
+
+  <table ng-repeat='comparison in comparisons' class="table table-bordered benchmarks">
+    <thead>
+      <tr class='active'>
+        <th colspan='4'>
+          {{comparison.environment}}
+          <a ng-click='hide = !hide' class='label label-default'>
+            <i ng-hide='hide' class='fa fa-minus'></i>
+            <i ng-hide='!hide' class='fa fa-plus'></i>
+          </a>
+        </th>
+      </tr>
+      <tr ng-hide='hide'>
+        <th style="width: 60%">name (sample size)</th>
+        <th class="text-right">current (stdev)</th>
+        <th class="text-right">previous (stdev)</th>
+        <th class="text-right">
+          change
+          <a class='label label-default' ng-click='reverse = false' ng-show='reverse'  ><i class='fa fa-sort-asc'></i></a>
+          <a class='label label-default' ng-click='reverse = true'  ng-show='!reverse' ><i class='fa fa-sort-desc'></i></a>
+        </th>
+      </tr>
+    </thead>
+    <tbody ng-hide='hide'>
+
+      <tr ng-repeat='item in comparison.data | filter:filterBenchmarksCompared(queryBenchmarks) | orderBy:"change":reverse '
+            ng-class="getChangeClass(item.change)" ng-show='showBoring || getChangeClass(item.change) != ""'>
+        <td>
+          {{ item.current.benchmark }} / <b>{{ item.current.name }}</b>
+          ({{ item.current.values.length }})
+        </td>
+        <td class="text-right">
+          {{ item.current.measurement.toFixed(2) }}<br/>
+          ({{ item.current.stdev.toFixed(2) }})
+        </td>
+        <td class="text-right">
+          {{ item.previous.measurement ? item.previous.measurement.toFixed(2) : "N/A" }}<br/>
+          {{ item.previous.stdev ? "(" + item.previous.stdev.toFixed(2) + ")": "" }}
+        </td>
+        <td class="text-right">
+          <b>
+            <span ng-if="item.change != null">
+              {{ item.change.toFixed(2) }} %
+            </span>
+          </b>
+          <span ng-if="item.change === null">
+            N/A
+          </span>
+        </td>
+      </tr>
+
+    </tbody>
+  </table>
+</div>
+
+
+</div>

--- a/frontend/static/templates/compare.html
+++ b/frontend/static/templates/compare.html
@@ -42,7 +42,8 @@
 
 </form>
 
-<i ng-show='loading && !ready' class='fa fa-cog fa-spin'></i>
+<i ng-show='loading && !ready && !error' class='fa fa-cog fa-spin'></i>
+<div ng-show='error' class='alert alert-warning'>{{error.statusText}}</div>
 
 <div ng-show="ready">
 

--- a/frontend/static/templates/compare.html
+++ b/frontend/static/templates/compare.html
@@ -67,6 +67,10 @@
 
   </form>
 
+  <div ng-show='comparisons.length == 0' class='alert alert-warning'>
+    No results to display
+  </div>
+
   <table ng-repeat='comparison in comparisons' class="table table-bordered benchmarks">
     <thead>
       <tr class='active'>

--- a/frontend/static/templates/compare.html
+++ b/frontend/static/templates/compare.html
@@ -1,3 +1,10 @@
+<div id='build-nav'>
+  <ul class="nav nav-pills nav-pills-sm">
+    <li role="presentation"><a href="#/builds/">build list</a></li>
+    <li role="presentation" class='active'><a href="#/builds/compare/">compare builds</a></li>
+  </ul>
+</div>
+
 <h1>
   Compare builds
   <span ng-show='buildFrom && buildTo'>

--- a/frontend/static/templates/manifest_list.html
+++ b/frontend/static/templates/manifest_list.html
@@ -46,7 +46,11 @@
             <tbody>
               <tr ng-repeat="result in item.results">
                 <td>
-                  <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
+                  <a ng-href="#/build/{{ result.id }}">
+                    #{{ result.id }}
+                   —
+                   {{ result.name }} #{{ result.build_id }}
+                  </a>
                 </td>
                 <td class="text-right">{{ result.gerrit_change_number }}</td>
                 <td class="text-right">{{ result.gerrit_patchset_number }}</td>

--- a/frontend/static/templates/manifest_reduced_list.html
+++ b/frontend/static/templates/manifest_reduced_list.html
@@ -46,7 +46,11 @@
 
                 <tr ng-repeat="result in manifest.results">
                   <td>
-                    <a ng-href="#/build/{{ result.id }}">#{{ result.build_id }} / {{ result.name }}</a>
+                    <a ng-href="#/build/{{ result.id }}">
+                      #{{ result.id }}
+                      —
+                      #{{ result.build_id }} {{ result.name }}
+                    </a>
                   </td>
                   <td class="text-right">
                     <small>


### PR DESCRIPTION
Every build that has a baseline build now has a "(compare)" link which will lead to the comparison page. You can also compare builds by selecting them in the build list, or by browsing directly to the  compare builds page (Builds - compare builds) and entering build numbers number there.