### PR TITLE
benchmarks/testminer: Removed assumption about benchmark name

### DIFF
--- a/benchmarks/testminer.py
+++ b/benchmarks/testminer.py
@@ -41,11 +41,21 @@ def extract_microbenchmarks(test_result_benchmarks, test_result_list):
         test_result = {}
         # benchmark iteration
         benchmark_group = '/'.join(full_benchmark_name.split('/')[0:-1]) + '/'
-        benchmark = full_benchmark_name.split('/')[-1].split('.')
-        test_result['benchmark_name'] = benchmark[0]
+        benchmark = full_benchmark_name.split('/')[-1]
+        split_benchmark = False
+        if '.' in benchmark:
+            split_benchmark = True
+            benchmark = benchmark.split('.')
+        if split_benchmark:
+            test_result['benchmark_name'] = benchmark[0]
+        else:
+            test_result['benchmark_name'] = benchmark
         test_result['benchmark_group'] = benchmark_group
         test_result['subscore'] = []
-        test_name = benchmark[1]
+        if split_benchmark:
+            test_name = benchmark[1]
+        else:
+            test_name = benchmark
         add_subscore_measurements(
             test_result['subscore'],
             test_name,

--- a/benchmarks/tests/test_testminer.py
+++ b/benchmarks/tests/test_testminer.py
@@ -96,3 +96,11 @@ class ArtMicrobenchmarksTestResultsTest(TestCase):
         self.assertEqual(len(test_results), 2)
         self.assertEqual(len([t for t in test_results if t['benchmark_group'] == 'benchmarks/group1/']), 1)
         self.assertEqual(len([t for t in test_results if t['benchmark_group'] == 'benchmarks/group2/']), 1)
+
+    def test_parse_test_results_3(self):
+        input_json = '{"benchmarks" : { "benchmarks/group1/Foo.Baz": [420897.5, 434825.5, 417673.0], "benchmarks/group1/FooBar": [5420897.5, 5434825.5, 5417673.0], "benchmarks/group2/Foo.Bar": [5420897.5, 5434825.5, 5417673.0] } }'
+        tester = ArtMicrobenchmarksTestResults('https://example.com/')
+        test_results = tester.parse_test_results(input_json)
+        self.assertEqual(len(test_results), 3)
+        self.assertEqual(len([t for t in test_results if t['benchmark_group'] == 'benchmarks/group1/']), 2)
+        self.assertEqual(len([t for t in test_results if t['benchmark_group'] == 'benchmarks/group2/']), 1)


### PR DESCRIPTION
It was assumed that benchmark names are in form Foo.Bar. The latest
results show that it's not always the case and there are results without
the '.' in character in the name.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>