### PR TITLE
API: fixed the simultaneus requests problem

### DIFF
--- a/benchmarks/migrations/0052_result_name_build_id_unique.py
+++ b/benchmarks/migrations/0052_result_name_build_id_unique.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('benchmarks', '0051_manifestreduced_created_at'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='result',
+            unique_together=set([('build_id', 'name')]),
+        ),
+    ]

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -99,6 +99,7 @@ class Result(models.Model):
 
     class Meta:
         index_together = ["build_id", "name"]
+        unique_together = ["build_id", "name"]
         ordering = ['-created_at']
 
     @property


### PR DESCRIPTION
When there were two requests coming at the same time trying to create a
Result object with the same data, it was possible to create two
identical objects. Since this didn't break database integrity it was
allowed. However the UI would present the results as two separate
'builds'. To prevent that 'build_id' and 'name' has to be unique
together. Now trying to create more than one Result object will raise
IntegrityError. This exception is handled in the api/views.py so the
outside behaviour for the user doesn't change.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>