### PR TITLE
frontend: rotate annotations by 90 degrees

### DIFF
--- a/frontend/static/main.js
+++ b/frontend/static/main.js
@@ -538,10 +538,9 @@ app.controller('Stats', ['$scope', '$http', '$routeParams', '$timeout', '$q', '$
                 width: 0.5,
                 value: item.x,
                 label: {
-                    rotation: 0,
+                    rotation: 90,
                     align: 'right',
-                    x: -5,
-                    style: { "width": "100px" },
+                    textAlign: 'left',
                     text: item.label
                 }
             }


### PR DESCRIPTION
If annotations are close enough, they overlap. Rotating annotations by
90 deg makes the problem less visible.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>